### PR TITLE
Docker container name for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,11 @@ clean:                              ## Clean docker stuff
 test: lint                               ## Execute tests
 	$(dc) run --rm test pytest /app/tests $(ARGS)
 
+# the name option is explicitly set, so the back- and frontend can communicate
+# with eachother while on the same docker network. The frontend docker-compose
+# file contains a reference to the set name
 dev: migrate						## Run the development app (and run extra migrations first)
-	$(run) --service-ports dev
+	$(run) --name bereikbaarheid-backend-django-dev --service-ports dev
 
 loadtest: migrate
 	$(manage) make_partitions $(ARGS)


### PR DESCRIPTION
This PR adds a container name when running `make dev`. With the name explicitly set, the back- and frontend can communicate with each other while on the same docker network. The `bereikbaarheid-frontend` docker-compose file contains a reference to this name.