### PR TITLE
bugfix permits api

### DIFF
--- a/src/bereikbaarheid/permits/permits.py
+++ b/src/bereikbaarheid/permits/permits.py
@@ -141,7 +141,7 @@ raw_query = """
             where v.id = (
                 SELECT id
                 from bereikbaarheid_out_vma_directed a
-                where id > 0
+                where id > 0 and car_network is true
                 order by st_length(
                     st_transform(
                         st_shortestline(


### PR DESCRIPTION
Met de permit api wordt obv het adres teruggegeven welke ontheffingen nodig zijn voor het voertuig. Hierbij wordt gekeken wat de dichtsbijzijnde link in het netwerk is. Soms is dit een link (wegvak) waar geen autoverkeer overheen kan, waardoor er niet over gerouteerd kan worden om te bepalen of er wel of nbiet een rvv ontheffing nodig is. Hierdoor geeft de api niks terug. 

Deze bugfix lost dit probleem op door het dichtsbijzijnde wegvak te kiezen waar wel autoverkeer overheen mag. 