### PR TITLE
replaced geometry::json in query to ST_AsGeoJson(geometry)::json

### DIFF
--- a/src/bereikbaarheid/isochrones/isochrones.py
+++ b/src/bereikbaarheid/isochrones/isochrones.py
@@ -4,7 +4,7 @@ raw_query = """
 select 
     abs(sub.id) as id,
     min(totalcost)::int as totalcost,
-    geom::json as geometry
+    ST_AsgeoJson(geom)::json as geometry
 from (
     select id,
     (0.5 * cost+source.agg_cost) * 3600 as totalcost

--- a/src/bereikbaarheid/obstructions/obstructions.py
+++ b/src/bereikbaarheid/obstructions/obstructions.py
@@ -4,7 +4,7 @@ from bereikbaarheid.utils import django_query_db
 
 raw_query = """
     select 
-        ST_Transform(t1.geom, 4326)::json as geometry,
+        ST_AsgeoJson(ST_Transform(t1.geom, 4326))::json as geometry,
         t1.link_nr as road_element_id,
         t1.name as road_element_street_name,
         t2."bereikbaar_status_code" as road_element_accessibility_code,

--- a/src/bereikbaarheid/permits/permits.py
+++ b/src/bereikbaarheid/permits/permits.py
@@ -36,9 +36,9 @@ raw_query = """
         else 'true'
     end as boolean_in_amsterdam,
 
-    ST_closestpoint(
+    ST_AsgeoJson(ST_closestpoint(
         v.geom,st_setsrid(ST_MakePoint(%(lon)s, %(lat)s), 4326)
-    )::json as geom,
+    ))::json as geom,
 
     st_length(
         st_transform(

--- a/src/health/views.py
+++ b/src/health/views.py
@@ -9,7 +9,6 @@ log = logging.getLogger(__name__)
 
 def health(request):
     # check debug
-    print(settings.DEBUG)
     if settings.DEBUG:
         log.exception("Debug mode not allowed in production")
         return HttpResponse(


### PR DESCRIPTION
Fix om de json(geometry) functie van postgis-extensie 3 (op huidige db van vnor) toch soort van te laten werken in postgis-extensie 2.5 (op acc db van datapunt). Let op: de json geometry velden worden met ST_AsGeoJson niet meer aangevuld met de csr informatie!! Dus als postgis3 beschikbaar is op de acc.db is aan te raden deze functie weer te verwijderen uit de queries.