### PR TITLE
extend allowed formats for import date fields

### DIFF
--- a/src/bereikbaarheid/resources/utils.py
+++ b/src/bereikbaarheid/resources/utils.py
@@ -127,7 +127,7 @@ def refresh_materialized(db_table: str):
 def convert_to_date(date: str = None) -> datetime:
     """Convert string format %d/%m/%y %H:%M or %Y-%m-%d %H:%M:%S.%f to datetime"""
 
-    formats_allowed = ["%d/%m/%y %H:%M", "%Y-%m-%d %H:%M:%S.%f"]
+    formats_allowed = ["%d/%m/%y %H:%M", "%Y-%m-%d %H:%M:%S.%f", "%d-%m-%Y %H:%M","%Y-%m-%d %H:%M:%S"]
 
     _date = None
 


### PR DESCRIPTION
export bestand vanuit applicatie kon niet opnieuw ingelezen worden door fout datetimeformat. De toegestane formats daarom uitgebreid.