### PR TITLE
chore: Removed call to super in OIDCAuthenticationBackend.verify_claims

### DIFF
--- a/src/main/auth.py
+++ b/src/main/auth.py
@@ -13,9 +13,8 @@ def oidc_login(request, **kwargs):
 
 class OIDCAuthenticationBackend(amsterdam_django_oidc.OIDCAuthenticationBackend):
     def verify_claims(self, claims):
-        verified = super(OIDCAuthenticationBackend, self).verify_claims(claims)
-        has_roles = claims.get("roles")
-        return verified and has_roles
+        has_roles = bool(claims.get("roles", []))
+        return has_roles
 
     def create_user(self, claims):
         user = super(OIDCAuthenticationBackend, self).create_user(claims)


### PR DESCRIPTION
Because we have custom OIDC_RP_SCOPES we need to override the verify_claims. No call to super is needed because this shows the warning that the verify_claims needs to be overridden.